### PR TITLE
Added parens to fix bitwise test failing due to precedence in maybe_d…

### DIFF
--- a/start.exe.c
+++ b/start.exe.c
@@ -235,7 +235,7 @@ maybe_dos_exe (FILE* file, char* filename)
   assert (NULL != filename);
   file_seek (file, filename, 0x18);
   read_bytes (file, filename, 1);
-  if (0 == bytes[0] & 0xc0) {
+  if (0 == (bytes[0] & 0xc0)) {
     (void) fclose (file);
     start_as_dos (filename);
   }


### PR DESCRIPTION
maybe_dos_exe() fails to detect DOS executables because == has a higher precedence that & 